### PR TITLE
Fixed quoting error

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -136,7 +136,7 @@ cp "/tmp/$old_directory/$old_sub_directory"/zero.bin.* "/tmp/${version}-simplypr
 cp "/tmp/$old_directory/$old_sub_directory"/xImage.* "/tmp/${version}-simplyprint/$directory/$sub_directory/"
 
 pushd "/tmp/${version}-simplyprint/$directory/$sub_directory" > /dev/null || exit $?
-split -d -b 1048576 -a 4 "/tmp/${version}-simplyprint/rootfs.squashfs rootfs.squashfs."
+split -d -b 1048576 -a 4 "/tmp/${version}-simplyprint/rootfs.squashfs" "rootfs.squashfs."
 popd > /dev/null || exit $?
 
 part_md5=


### PR DESCRIPTION
This quoting error caused the 2 parameters to become 1 and the command failed. The resulting image was, therefore onlt 4.5MB instead of 103MB.